### PR TITLE
There are typos in requirement and conversion script and add support for google colab

### DIFF
--- a/main.py
+++ b/main.py
@@ -22,7 +22,7 @@ uploaded_file = None
 
 DEFAULT_CONCURRENCY = int(os.getenv("DEFAULT_CONCURRENCY", 2))
 
-script_path = "llama.cpp/convert-hf-to-gguf.py"
+script_path = "llama.cpp/convert_hf_to_gguf.py"
 # Define the enum
 ggml_type_enum = {
     "Q4_0": 2,

--- a/run.sh
+++ b/run.sh
@@ -33,5 +33,16 @@ cd ..
 
 if [ "$DOCKER_BUILD" != true ]; then
   echo "Starting Streamlit..."
-  streamlit run main.py --browser.serverAddress 0.0.0.0
+  # Check if running in Google Colab
+  if [ -d "/content" ] || [ -n "${COLAB_RELEASE_TAG+x}" ]; then
+    echo "Running in Google Colab. Fetching public IP..."
+    PUBLIC_IP=$(wget -q -O - ipv4.icanhazip.com)
+    echo "Public IP: $PUBLIC_IP"
+    
+    # Start Streamlit and localtunnel
+    streamlit run main.py & npx localtunnel --port 8501
+  else
+    # Not running in Colab, start Streamlit normally
+    streamlit run main.py --browser.serverAddress 0.0.0.0
+  fi
 fi

--- a/run.sh
+++ b/run.sh
@@ -19,7 +19,7 @@ else
 fi
 
 pip install --upgrade huggingface_hub pip streamlit watchdog
-pip install -r "llama.cpp/requirements/requirements-convert-hf-to-gguf.txt"
+pip install -r "llama.cpp/requirements/requirements-convert_hf_to_gguf.txt"
 cd llama.cpp
 
 # if CUDA is available, set the llama.cpp build options


### PR DESCRIPTION
This PR is to

a.  fix typos in the requirement and conversion scripts. The underscores are miss placed :)

i. In [run.sh](https://github.com/kevkid/gguf_gui/blob/c96737b9f6c8f46648585f47e83cf1a202f83dba/run.sh#L22) requirements-convert-hf-to-gguf.txt should have underscores separating the words "convert hf to gguf"

ii. In [main.py](https://github.com/kevkid/gguf_gui/blob/c96737b9f6c8f46648585f47e83cf1a202f83dba/main.py#L25) the hyphens separating the words "convert hf to gguf" should be replaced by underscores.

b. Add support for google colab. Currently the streamlit command doesn't expose the IP for a user to pull up the URL in a browser. The fix is to check if it's running in colab and spin a localtunnel to open the url in browser.

Thank you!